### PR TITLE
Feat/1 공통 모듈 생성 및 초기 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.pagely'
-version = '1.0.0'
+version = '1.0.1'
 
 java {
     toolchain {

--- a/build.gradle
+++ b/build.gradle
@@ -1,33 +1,124 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.14'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java-library'
+    id 'maven-publish'
 }
 
 group = 'com.pagely'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.0'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+    withSourcesJar()
+    withJavadocJar()
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
+}
+
+// Spring Boot BOM을 version catalog로 관리 (소비자에게 강제하지 않음)
+ext {
+    springBootVersion = '3.5.1'
+    lombokVersion = '1.18.34'
+    querydslVersion = '5.1.0'
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testCompileOnly 'org.projectlombok:lombok'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testAnnotationProcessor 'org.projectlombok:lombok'
+    // ── BOM (소비자에게 전이되지 않음, 라이브러리 컴파일용) ──────────────────
+    compileOnly platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+    annotationProcessor platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+    testImplementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+
+    // ── Lombok ──────────────────────────────────────────────────────────────
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+
+    // ── Jackson ──────────────────────────
+    compileOnly "com.fasterxml.jackson.core:jackson-databind"
+
+    // ── JPA (소비자가 Spring Data JPA 를 사용한다고 가정) ────────────────────
+    compileOnly "jakarta.persistence:jakarta.persistence-api"
+    compileOnly "org.springframework.data:spring-data-commons"
+    compileOnly "org.springframework.data:spring-data-jpa"
+
+    // ── QueryDSL (Q 슈퍼타입 클래스 생성 — QBaseTime, QBaseAudit) ───────────
+    compileOnly "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    api "com.querydsl:querydsl-core:${querydslVersion}"
+
+    // ── Spring Web/MVC (GlobalExceptionHandler 용) ───────────────────────────
+    compileOnly "org.springframework:spring-web"
+    compileOnly "org.springframework:spring-webmvc"
+    compileOnly "org.springframework.boot:spring-boot-autoconfigure"
+    compileOnly "jakarta.validation:jakarta.validation-api"
+    compileOnly "jakarta.servlet:jakarta.servlet-api"
+
+    // ── Test ─────────────────────────────────────────────────────────────────
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-web")
+    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    testRuntimeOnly("com.h2database:h2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            versionMapping {
+                usage("java-api") {
+                    fromResolutionOf("runtimeClasspath")
+                }
+                usage("java-runtime") {
+                    fromResolutionResult()
+                }
+            }
+            pom {
+                name = "Common Library"
+                description = "MSA 공통 라이브러리 (Entity, Pagination, Exception, Response)"
+            }
+        }
+    }
+    repositories {
+        mavenLocal()
+
+        def gprUser = providers.gradleProperty("gpr.user").orNull
+        def gprPass = providers.gradleProperty("gpr.key").orNull
+
+        println(">>> [DEBUG] GPR_USER env       = ${System.getenv('GPR_USER')}")
+        println(">>> [DEBUG] GPR_TOKEN env        = ${System.getenv('GPR_TOKEN') != null ? 'SET(' + System.getenv('GPR_TOKEN').length() + 'chars)' : 'NULL'}")
+        println(">>> [DEBUG] GitHubPackagesUsername  = ${gprUser}")
+        println(">>> [DEBUG] GitHubPackagesPassword  = ${gprPass != null ? 'SET(' + gprPass.length() + 'chars)' : 'NULL'}")
+
+        if (gprUser != null && gprPass != null) {
+            println(">>> [DEBUG] GitHubPackages 저장소 추가됨 → PublishToMavenRepository task 생성")
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/Pagely-wisely/common")
+                credentials {
+                    username = gprUser ?: System.getenv('GPR_USER')
+                    password = gprPass ?: System.getenv('GPR_USER')
+                }
+            }
+        } else {
+            println(">>> [DEBUG] GitHubPackages 저장소 건너뜀 (프로퍼티 없음) → task 미생성")
+        }
+    }
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
+}
+
+tasks.withType(Javadoc) {
+    options.encoding = "UTF-8"
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ publishing {
                 url = uri("https://maven.pkg.github.com/Pagely-wisely/common")
                 credentials {
                     username = gprUser ?: System.getenv('GPR_USER')
-                    password = gprPass ?: System.getenv('GPR_USER')
+                    password = gprPass ?: System.getenv('GPR_TOKEN')
                 }
             }
         } else {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/pagely/common/config/CommonWebAutoConfiguration.java
+++ b/src/main/java/com/pagely/common/config/CommonWebAutoConfiguration.java
@@ -1,0 +1,33 @@
+package com.pagely.common.config;
+
+import com.pagely.common.pagination.PageRequestArgumentResolver;
+import com.pagely.common.web.GlobalExceptionHandler;
+import java.util.List;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web MVC 환경에서 공통 빈 자동 등록.
+ *
+ * <p>{@link GlobalExceptionHandler} 를 직접 정의한 서비스에서는 이 설정이 적용되지 않습니다.
+ * <p>{@link PageRequestArgumentResolver} 는 항상 등록됩니다.
+ */
+@AutoConfiguration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+public class CommonWebAutoConfiguration implements WebMvcConfigurer {
+
+    @Bean
+    @ConditionalOnMissingBean(GlobalExceptionHandler.class)
+    public GlobalExceptionHandler globalExceptionHandler() {
+        return new GlobalExceptionHandler();
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new PageRequestArgumentResolver());
+    }
+}

--- a/src/main/java/com/pagely/common/entity/BaseEntity.java
+++ b/src/main/java/com/pagely/common/entity/BaseEntity.java
@@ -1,0 +1,56 @@
+package com.pagely.common.entity;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@Access(AccessType.FIELD)
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    protected LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false, nullable = false)
+    protected UUID createdBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", insertable = false)
+    protected LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by", insertable = false)
+    protected UUID updatedBy;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    protected UUID deletedBy;
+
+    protected void softDelete(UUID deletedBy) {
+        if (this.deletedAt != null) {
+            return;
+        }
+        this.deletedBy = deletedBy;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+}

--- a/src/main/java/com/pagely/common/exception/BusinessException.java
+++ b/src/main/java/com/pagely/common/exception/BusinessException.java
@@ -9,14 +9,12 @@ import lombok.Getter;
  * - 서비스 레이어에서 발생하는 도메인/비즈니스 예외를 표현하기 위해 사용합니다. - ErrorCode를 기반으로 예외의 종류와 응답 메시지를 일관되게 관리합니다. - GlobalExceptionHandler에서
  * 해당 예외를 공통 포맷으로 변환하여 응답합니다.
  * </p>
- *
  * <p>
  * 사용 예시:
  * <pre>{@code
  * throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
  * throw new BusinessException(UserErrorCode.INVALID_PASSWORD, "비밀번호가 일치하지 않습니다.");
  * }</pre>
- * </p>
  */
 @Getter
 public class BusinessException extends RuntimeException {

--- a/src/main/java/com/pagely/common/exception/BusinessException.java
+++ b/src/main/java/com/pagely/common/exception/BusinessException.java
@@ -1,0 +1,69 @@
+package com.pagely.common.exception;
+
+import lombok.Getter;
+
+/**
+ * 비즈니스 로직 처리 중 발생하는 예외를 표현하는 커스텀 예외 클래스
+ *
+ * <p>
+ * - 서비스 레이어에서 발생하는 도메인/비즈니스 예외를 표현하기 위해 사용합니다. - ErrorCode를 기반으로 예외의 종류와 응답 메시지를 일관되게 관리합니다. - GlobalExceptionHandler에서
+ * 해당 예외를 공통 포맷으로 변환하여 응답합니다.
+ * </p>
+ *
+ * <p>
+ * 사용 예시:
+ * <pre>{@code
+ * throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+ * throw new BusinessException(UserErrorCode.INVALID_PASSWORD, "비밀번호가 일치하지 않습니다.");
+ * }</pre>
+ * </p>
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    /**
+     * 기본 생성자
+     *
+     * <p>
+     * ErrorCode에 정의된 기본 메시지를 사용하여 예외를 생성합니다.
+     * </p>
+     *
+     * @param errorCode 공통 에러 코드
+     */
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * 상세 메시지를 포함한 생성자
+     *
+     * <p>
+     * ErrorCode의 기본 메시지 대신 커스텀 메시지를 사용하고 싶을 때 사용합니다.
+     * </p>
+     *
+     * @param errorCode     공통 에러 코드
+     * @param detailMessage 사용자 정의 상세 메시지
+     */
+    public BusinessException(ErrorCode errorCode, String detailMessage) {
+        super(detailMessage);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * 원인 예외를 포함한 생성자
+     *
+     * <p>
+     * 하위 예외를 감싸서 전달할 때 사용합니다. (Exception Wrapping)
+     * </p>
+     *
+     * @param errorCode 공통 에러 코드
+     * @param cause     원인이 되는 예외
+     */
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/pagely/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/pagely/common/exception/CommonErrorCode.java
@@ -1,0 +1,36 @@
+package com.pagely.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 공통 에러 코드.
+ */
+@Getter
+public enum CommonErrorCode implements ErrorCode {
+
+    // 4xx
+    INVALID_INPUT("입력값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    RESOURCE_NOT_FOUND("요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED("인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    CONFLICT("요청이 현재 상태와 충돌합니다.", HttpStatus.CONFLICT),
+    UNSUPPORTED_MEDIA_TYPE("지원하지 않는 미디어 타입입니다.", HttpStatus.UNSUPPORTED_MEDIA_TYPE),
+    TOO_MANY_REQUESTS("요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.", HttpStatus.TOO_MANY_REQUESTS),
+
+    // 5xx
+    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    SERVICE_UNAVAILABLE("서비스를 일시적으로 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    EVENT_PUBLISH_FAILURE("이벤트 발행에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    CommonErrorCode(String message, HttpStatus httpStatus) {
+        this.code = this.name();
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/com/pagely/common/exception/ErrorCode.java
+++ b/src/main/java/com/pagely/common/exception/ErrorCode.java
@@ -1,0 +1,4 @@
+package com.pagely.common.exception;
+
+public interface ErrorCode {
+}

--- a/src/main/java/com/pagely/common/exception/ErrorCode.java
+++ b/src/main/java/com/pagely/common/exception/ErrorCode.java
@@ -1,4 +1,15 @@
 package com.pagely.common.exception;
 
+import org.springframework.http.HttpStatus;
+
 public interface ErrorCode {
+
+    // ErrorCode Enum Name (예시: BAD_REQUEST, USER_NOT_FOUND)
+    String getCode();
+
+    // 사용자에게 노출할 메시지
+    String getMessage();
+
+    // HTTP 상태 코드
+    HttpStatus getHttpStatus();
 }

--- a/src/main/java/com/pagely/common/exception/ErrorCode.java
+++ b/src/main/java/com/pagely/common/exception/ErrorCode.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public interface ErrorCode {
 
-    // ErrorCode Enum Name (예시: BAD_REQUEST, USER_NOT_FOUND)
+    // ErrorCode -> Enum Name (예시: BAD_REQUEST, USER_NOT_FOUND)
     String getCode();
 
     // 사용자에게 노출할 메시지

--- a/src/main/java/com/pagely/common/pagination/PageRequest.java
+++ b/src/main/java/com/pagely/common/pagination/PageRequest.java
@@ -1,0 +1,56 @@
+package com.pagely.common.pagination;
+
+import java.util.Set;
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ * 허용된 사이즈(10 / 30 / 50)만 받는 페이지 요청 DTO.
+ *
+ * <p>허용되지 않은 사이즈는 기본값 10으로 대체됩니다.
+ *
+ * <pre>{@code
+ * // Controller
+ * @GetMapping("/users")
+ * public ApiResponse<PageResponse<UserResponse>> list(
+ *         @RequestParam(defaultValue = "0") int page,
+ *         @RequestParam(defaultValue = "10") int size) {
+ *
+ *     Pageable pageable = PageRequest.of(page, size).toPageable();
+ *     return ApiResponse.success(PageResponse.of(userService.list(pageable)));
+ * }
+ * }</pre>
+ */
+@Getter
+public class PageRequest {
+
+    public static final Set<Integer> ALLOWED_SIZES = Set.of(10, 30, 50);
+    public static final int DEFAULT_SIZE = 10;
+
+    private final int page;   // 0-based
+    private final int size;   // 10 | 30 | 50
+
+    private PageRequest(int page, int size) {
+        this.page = Math.max(0, page);
+        this.size = ALLOWED_SIZES.contains(size) ? size : DEFAULT_SIZE;
+    }
+
+    public static PageRequest of(int page, int size) {
+        return new PageRequest(page, size);
+    }
+
+    /**
+     * Spring Data {@link Pageable} 로 변환 (정렬 없음).
+     */
+    public Pageable toPageable() {
+        return org.springframework.data.domain.PageRequest.of(page, size);
+    }
+
+    /**
+     * Spring Data {@link Pageable} 로 변환 (정렬 포함).
+     */
+    public Pageable toPageable(Sort sort) {
+        return org.springframework.data.domain.PageRequest.of(page, size, sort);
+    }
+}

--- a/src/main/java/com/pagely/common/pagination/PageRequestArgumentResolver.java
+++ b/src/main/java/com/pagely/common/pagination/PageRequestArgumentResolver.java
@@ -1,0 +1,53 @@
+package com.pagely.common.pagination;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * 컨트롤러 파라미터로 선언된 {@link PageRequest}를 쿼리 파라미터에서 자동 바인딩.
+ *
+ * <p>{@code ?page=0&size=10} 형태로 요청하면 {@link PageRequest}로 변환됩니다.
+ * 허용되지 않은 size 값은 {@link PageRequest#DEFAULT_SIZE}(10)으로 대체됩니다.
+ *
+ * <pre>{@code
+ * @GetMapping("/items")
+ * public ApiResponse<PageResponse<ItemResponse>> list(PageRequest pageRequest) {
+ *     return ApiResponse.success(itemService.list(pageRequest.toPageable()));
+ * }
+ * }</pre>
+ */
+public class PageRequestArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return PageRequest.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        String pageParam = webRequest.getParameter("page");
+        String sizeParam = webRequest.getParameter("size");
+
+        int page = parseOrDefault(pageParam, 0);
+        int size = parseOrDefault(sizeParam, PageRequest.DEFAULT_SIZE);
+
+        return PageRequest.of(page, size);
+    }
+
+    private int parseOrDefault(String value, int defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/src/main/java/com/pagely/common/pagination/PageResponse.java
+++ b/src/main/java/com/pagely/common/pagination/PageResponse.java
@@ -1,0 +1,85 @@
+package com.pagely.common.pagination;
+
+import java.util.List;
+import java.util.function.Function;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+
+/**
+ * 페이지네이션 응답 DTO.
+ *
+ * <p>Spring Data 의 {@link Page} 를 JSON 직렬화에 적합한 형태로 래핑합니다.
+ *
+ * <pre>{@code
+ * Page<UserEntity> page = userRepository.findAll(pageable);
+ * PageResponse<UserResponse> response = PageResponse.of(page, UserResponse::from);
+ * }</pre>
+ *
+ * @param <T> 콘텐츠 항목 타입
+ */
+@Getter
+@RequiredArgsConstructor
+public class PageResponse<T> {
+
+    private final List<T> content;
+    private final int page;          // 0-based
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+
+    private PageResponse(List<T> content, int page, int size,
+                         long totalElements, int totalPages,
+                         boolean first, boolean last) {
+        this.content = content;
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+    }
+
+    // ── 팩토리 ────────────────────────────────────────────────────────────────
+
+    /**
+     * Spring Data {@link Page} 를 그대로 변환.
+     */
+    public static <T> PageResponse<T> of(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
+    }
+
+    /**
+     * 엔티티 Page → DTO Page 로 변환 (매핑 함수 제공).
+     *
+     * @param page   Spring Data Page
+     * @param mapper 엔티티 → DTO 변환 함수
+     */
+    public static <E, T> PageResponse<T> of(Page<E> page, Function<E, T> mapper) {
+        return new PageResponse<>(
+                page.getContent().stream().map(mapper).toList(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
+    }
+
+    /**
+     * Spring Data 의존 없이 직접 생성.
+     */
+    public static <T> PageResponse<T> of(List<T> content, int page, int size, long totalElements) {
+        int totalPages = size == 0 ? 1 : (int) Math.ceil((double) totalElements / size);
+        return new PageResponse<>(
+                content,
+                page,
+                size,
+                totalElements,
+                totalPages
+        );
+    }
+}

--- a/src/main/java/com/pagely/common/response/ApiResponse.java
+++ b/src/main/java/com/pagely/common/response/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.pagely.common.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.pagely.common.exception.ErrorCode;
 import com.pagely.common.pagination.PageResponse;
 import java.util.List;
@@ -13,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse {
 
     private final boolean success;

--- a/src/main/java/com/pagely/common/response/ApiResponse.java
+++ b/src/main/java/com/pagely/common/response/ApiResponse.java
@@ -1,0 +1,78 @@
+package com.pagely.common.response;
+
+import com.pagely.common.exception.ErrorCode;
+import com.pagely.common.pagination.PageResponse;
+import java.util.List;
+import java.util.function.Function;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse {
+
+    private final boolean success;
+    private final Object data;
+    private final ErrorResponse error;
+
+    // ── ResponseEntity 반환 (컨트롤러에서 바로 return) ────────────────────────
+
+    public static ResponseEntity<ApiResponse> ok(Object data) {
+        return ResponseEntity.ok(new ApiResponse(true, data, null));
+    }
+
+    public static ResponseEntity<ApiResponse> ok() {
+        return ResponseEntity.ok(new ApiResponse(true, null, null));
+    }
+
+    public static ResponseEntity<ApiResponse> created(Object data) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse(true, data, null));
+    }
+
+    public static ResponseEntity<ApiResponse> created() {
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse(true, null, null));
+    }
+
+    public static <T> ResponseEntity<ApiResponse> ok(Page<T> page) {
+        return ResponseEntity.ok(new ApiResponse(true, PageResponse.of(page), null));
+    }
+
+    public static <E, T> ResponseEntity<ApiResponse> ok(Page<E> page, Function<E, T> mapper) {
+        return ResponseEntity.ok(new ApiResponse(true, PageResponse.of(page, mapper), null));
+    }
+
+    public static ApiResponse success(Object data) {
+        return new ApiResponse(true, data, null);
+    }
+
+    public static ApiResponse success() {
+        return new ApiResponse(true, null, null);
+    }
+
+    public static <T> ApiResponse page(Page<T> page) {
+        return new ApiResponse(true, PageResponse.of(page), null);
+    }
+
+    public static <E, T> ApiResponse page(Page<E> page, Function<E, T> mapper) {
+        return new ApiResponse(true, PageResponse.of(page, mapper), null);
+    }
+
+    public static ApiResponse error(ErrorCode errorCode) {
+        return new ApiResponse(false, null,
+                ErrorResponse.of(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    public static ApiResponse error(ErrorCode errorCode, String detailMessage) {
+        return new ApiResponse(false, null,
+                ErrorResponse.of(errorCode.getCode(), detailMessage));
+    }
+
+    public static ApiResponse error(ErrorCode errorCode, List<ErrorResponse.FieldError> fieldErrors) {
+        return new ApiResponse(false, null,
+                ErrorResponse.of(errorCode.getCode(), errorCode.getMessage(), fieldErrors));
+    }
+}

--- a/src/main/java/com/pagely/common/response/ErrorResponse.java
+++ b/src/main/java/com/pagely/common/response/ErrorResponse.java
@@ -1,0 +1,40 @@
+package com.pagely.common.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 에러 상세 정보 DTO.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+
+    private String code;
+    private String message;
+    private List<FieldError> fieldErrors;
+
+    public static ErrorResponse of(String code, String message) {
+        return new ErrorResponse(code, message, null);
+    }
+
+    public static ErrorResponse of(String code, String message, List<FieldError> fieldErrors) {
+        return new ErrorResponse(code, message, fieldErrors);
+    }
+
+    /**
+     * Bean Validation 필드 오류 정보.
+     */
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(staticName = "of")
+    public static class FieldError {
+        private String field;
+        private Object rejectedValue;
+        private String reason;
+    }
+}

--- a/src/main/java/com/pagely/common/response/ErrorResponse.java
+++ b/src/main/java/com/pagely/common/response/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.pagely.common.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
 
     private String code;

--- a/src/main/java/com/pagely/common/web/GlobalExceptionHandler.java
+++ b/src/main/java/com/pagely/common/web/GlobalExceptionHandler.java
@@ -1,0 +1,101 @@
+package com.pagely.common.web;
+
+import com.pagely.common.exception.BusinessException;
+import com.pagely.common.exception.CommonErrorCode;
+import com.pagely.common.response.ApiResponse;
+import com.pagely.common.response.ErrorResponse;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+/**
+ * 전역 예외 처리기.
+ *
+ * <p>Auto-configuration 으로 자동 등록됩니다.
+ * 소비자 서비스에서 동일 타입 빈을 등록하면 이 핸들러는 등록되지 않습니다 ({@code @ConditionalOnMissingBean}).
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // ── 비즈니스 예외 ──────────────────────────────────────────────────────────
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse> handleBusinessException(BusinessException e) {
+        log.warn("[BusinessException] code={}, message={}", e.getErrorCode().getCode(), e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ApiResponse.error(e.getErrorCode(), e.getMessage()));
+    }
+
+    // ── Bean Validation 예외 (@Valid, @Validated) ────────────────────────────
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        List<ErrorResponse.FieldError> fieldErrors = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> ErrorResponse.FieldError.of(
+                        fe.getField(),
+                        fe.getRejectedValue(),
+                        fe.getDefaultMessage()))
+                .toList();
+        log.warn("[ValidationException] fieldErrors={}", fieldErrors);
+        return ResponseEntity
+                .status(CommonErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT, fieldErrors));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse> handleBindException(BindException e) {
+        List<ErrorResponse.FieldError> fieldErrors = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> ErrorResponse.FieldError.of(
+                        fe.getField(),
+                        fe.getRejectedValue(),
+                        fe.getDefaultMessage()))
+                .toList();
+        return ResponseEntity
+                .status(CommonErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT, fieldErrors));
+    }
+
+    // ── 요청 파라미터 예외 ────────────────────────────────────────────────────
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse> handleMissingParam(MissingServletRequestParameterException e) {
+        return ResponseEntity
+                .status(CommonErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT,
+                        "필수 파라미터 누락: " + e.getParameterName()));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity
+                .status(CommonErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT,
+                        "파라미터 타입 오류: " + e.getName()));
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ApiResponse> handleUnsupportedMediaType(HttpMediaTypeNotSupportedException e) {
+        return ResponseEntity
+                .status(CommonErrorCode.UNSUPPORTED_MEDIA_TYPE.getHttpStatus())
+                .body(ApiResponse.error(CommonErrorCode.UNSUPPORTED_MEDIA_TYPE));
+    }
+
+    // ── 예상치 못한 예외 (최후 방어선) ───────────────────────────────────────
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse> handleException(Exception e) {
+        log.error("[UnhandledException] {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(CommonErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ApiResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,1 @@
-com.followMe.common.autoconfigure.CommonWebAutoConfiguration
+com.pasely.common.config.CommonWebAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.followMe.common.autoconfigure.CommonWebAutoConfiguration

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,0 @@
-spring:
-  application:
-    name: common


### PR DESCRIPTION
## 📝 작업 내용
> 공통 모듈 생성 및 초기 세팅

- 감사필드 엔티티
- 공통 응답
- 공통예외처리
- 페이징 DTO

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #1
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #1

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

가이드 문서 추가 작성해서 공유하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 페이지네이션 지원 추가 — 허용 크기(10,30,50), 쿼리 파라미터 자동 바인딩 및 Pageable 변환.
  * 일관된 API 응답 포맷 도입 — 성공/페이징/오류 응답 헬퍼 제공.
  * 중앙화된 예외 처리 도입 — 비즈니스 예외, 검증 오류, 타입/파라미터/미디어 오류에 대한 구조화된 오류 응답 반환.
  * 공통 엔티티 기능 추가 — 생성/수정 감사 필드 및 소프트 삭제 지원.
  * 표준화된 에러 코드 타입 추가 — 상태 코드 및 메시지 매핑 제공.

* **Chores**
  * 빌드·퍼블리시 구성 개선 및 Java 도구체인/소스·Javadoc JAR 생성 설정 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->